### PR TITLE
System.Net.Sockets - Substitute appropriate exceptions for asserts

### DIFF
--- a/src/Common/tests/System/Net/Sockets/SocketTestServerAsync.cs
+++ b/src/Common/tests/System/Net/Sockets/SocketTestServerAsync.cs
@@ -140,7 +140,10 @@ namespace System.Net.Sockets.Tests
             }
 
             _log.WriteLine(this.GetHashCode() + " StartAccept(_numConnectedSockets={0})", _numConnectedSockets);
-            Assert.True(_maxNumberAcceptedClientsSemaphore.WaitOne(TestSettings.PassingTestTimeout), "Timeout waiting for client connection.");
+            if (!_maxNumberAcceptedClientsSemaphore.WaitOne(TestSettings.PassingTestTimeout))
+            {
+                throw new TimeoutException("Timeout waiting for client connection.");
+            }
 
             if (_listenSocket == null)
             {
@@ -188,8 +191,7 @@ namespace System.Net.Sockets.Tests
 
                 if (Interlocked.Decrement(ref _acceptRetryCount) <= 0)
                 {
-                    Assert.True(false, "accept retry limit exceeded.");
-                    return;
+                    throw new Exception("accept retry limit exceeded.");
                 }
 
                 Task.Delay(500).Wait();

--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -361,7 +361,7 @@ namespace System.Net.Sockets.Tests
 
         public void CallbackThatShouldNotBeCalled(object sender, SocketAsyncEventArgs args)
         {
-            Assert.True(false, "This Callback should not be called");
+            throw new ShouldNotBeInvokedException();
         }
 
         [OuterLoop] // TODO: Issue #11345

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -86,6 +86,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Capability.Sockets.cs">
       <Link>Common\System\Net\Capability.Sockets.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+      <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Sockets\SocketAPMExtensions.cs">
       <Link>Common\System\Net\Sockets\SocketAPMExtensions.cs</Link>
     </Compile>


### PR DESCRIPTION
Mock/test support objects, not directly part of tests.

